### PR TITLE
chore: share team Claude settings, onboard command, and knowledge graph

### DIFF
--- a/.claude/commands/drunk-team-onboard.md
+++ b/.claude/commands/drunk-team-onboard.md
@@ -1,0 +1,113 @@
+---
+description: Share Claude plugin settings with the team, build/refresh the Understand-Anything knowledge graph with auto-update, and git-lfs track it — then stage everything for review.
+argument-hint: "[--force] [--language <lang>]  (passed through to /understand)"
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill
+---
+
+# /drunk-team-onboard
+
+Make this repo onboarding-ready for the team in one pass:
+
+1. Generate a **shareable `.claude/settings.json`** (plugins + marketplaces) from the maintainer's live setup.
+2. Build/refresh the **Understand-Anything knowledge graph** with auto-update enabled.
+3. **git-lfs track** the graph and **stage** everything — leaving the commit to a human.
+
+This command is **idempotent** — safe to re-run. It **never commits or pushes**; it only stages.
+`$ARGUMENTS` (e.g. `--force`, `--language zh`) is forwarded to `/understand`.
+
+Plugin source: Understand-Anything (Egonex fork) — <https://github.com/Egonex-AI/Understand-Anything>
+
+---
+
+## Step 0 — Preconditions (stop on any failure, fail loud)
+
+```bash
+git rev-parse --is-inside-work-tree                 # must be a git repo
+git rev-parse --abbrev-ref HEAD                      # report branch; warn if it is the default/protected branch
+command -v git-lfs || echo "MISSING: git-lfs — install it (brew install git-lfs) before continuing"
+command -v jq      || echo "MISSING: jq — install it (brew install jq) before continuing"
+```
+
+- If not a git repo, or `git-lfs`/`jq` are missing → **report and STOP**. Do not partially apply.
+- If on a protected branch (e.g. `develop`/`main`), warn and ask the user to switch to a feature branch first.
+
+---
+
+## Step 1 — Generate the shareable `.claude/settings.json`
+
+Goal: teammates who clone the repo get the **same plugins + marketplaces** the maintainer uses, with **no machine-specific data leaked**.
+
+Copy **only** `enabledPlugins` and `extraKnownMarketplaces` from the maintainer's user settings into the repo settings. Do **NOT** copy `hooks`, `permissions`, `env`, or any key holding absolute paths or local tooling (those are per-machine and may expose private paths).
+
+```bash
+USER_SETTINGS="$HOME/.claude/settings.json"
+REPO_SETTINGS=".claude/settings.json"
+
+mkdir -p .claude
+[ -f "$REPO_SETTINGS" ] || echo '{}' > "$REPO_SETTINGS"
+
+# Merge: repo settings win on scalar keys; the two plugin maps are unioned
+# (user entries layered on top of any existing repo entries). Only these two
+# keys are taken from user settings — nothing else crosses over.
+jq -s '
+  .[0] as $repo | .[1] as $user
+  | $repo
+  + { enabledPlugins:        (($repo.enabledPlugins        // {}) + ($user.enabledPlugins        // {})) }
+  + { extraKnownMarketplaces: (($repo.extraKnownMarketplaces // {}) + ($user.extraKnownMarketplaces // {})) }
+' "$REPO_SETTINGS" "$USER_SETTINGS" > "$REPO_SETTINGS.tmp" && mv "$REPO_SETTINGS.tmp" "$REPO_SETTINGS"
+
+jq '{enabledPlugins, extraKnownMarketplaces}' "$REPO_SETTINGS"   # show the result for review
+```
+
+Notes:
+- This shares **currently-enabled** plugins (the in-use set). It does not pull disabled-but-installed plugins.
+- Some marketplaces may be **private** (require repo/org access). Flag any private marketplace so the user can confirm teammates can reach it.
+- Confirm `understand-anything@understand-anything` is present in `enabledPlugins` (needed for Step 2's auto-update hook to work on teammates' machines). If absent, tell the user to install it:
+  `/plugin marketplace add Egonex-AI/Understand-Anything` then `/plugin install understand-anything`.
+
+---
+
+## Step 2 — Build / refresh the knowledge graph (auto-update on)
+
+Run the skill **in the main thread** (it dispatches its own analyzer subagents — do not wrap it in a subagent):
+
+```
+/understand --auto-update $ARGUMENTS
+```
+
+- `--auto-update` writes `{"autoUpdate": true}` to `.understand-anything/config.json`. The plugin's bundled hook then incrementally patches the graph whenever a `git commit` is made (and on stale SessionStart), so each commit lands with a matching graph.
+- If a graph already exists, `/understand` runs incrementally. Pass `--force` (via `$ARGUMENTS`) to rebuild from scratch.
+- After it finishes, confirm these exist: `.understand-anything/knowledge-graph.json`, `.understand-anything/meta.json`, `.understand-anything/config.json` (with `autoUpdate: true`).
+
+---
+
+## Step 3 — Ignore scratch, git-lfs track the graph, and stage
+
+Scratch outputs must stay local (never committed):
+
+```bash
+# .gitignore — append only if missing (idempotent)
+for p in ".understand-anything/intermediate/" ".understand-anything/tmp/" ".understand-anything/diff-overlay.json"; do
+  grep -qxF "$p" .gitignore 2>/dev/null || echo "$p" >> .gitignore
+done
+
+# Large graphs (10 MB+) belong in LFS; tracking is harmless for small ones too.
+git lfs install
+git lfs track ".understand-anything/*.json"
+
+# Stage — but DO NOT commit. A human reviews and commits.
+git add .gitattributes .gitignore .claude/settings.json .understand-anything/
+
+git status
+git lfs ls-files          # confirm the graph json is LFS-tracked
+```
+
+---
+
+## Done — report, do not commit
+
+Summarize for the user:
+- Which plugins/marketplaces were written into `.claude/settings.json` (call out any private ones).
+- Graph status: created vs incrementally updated; `autoUpdate` on/off.
+- What is staged and confirmed LFS-tracked.
+- Remind them: **review, then commit yourself** (e.g. `git commit -m "chore: share team onboarding (claude settings + understand graph)"`). The auto-update hook keeps the graph fresh on every future commit.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "enabledPlugins": {
+    "caveman@caveman": true,
+    "claude-code-setup@claude-plugins-official": true,
+    "claude-smart@reflexioai": true,
+    "context-mode@context-mode": true,
+    "superpowers@claude-plugins-official": true,
+    "understand-anything@understand-anything": true,
+    "learning-output-style@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "caveman": {
+      "autoUpdate": true,
+      "source": {
+        "repo": "JuliusBrussee/caveman",
+        "source": "github"
+      }
+    },
+    "context-mode": {
+      "autoUpdate": true,
+      "source": {
+        "repo": "mksglu/context-mode",
+        "source": "github"
+      }
+    },
+    "reflexioai": {
+      "source": {
+        "repo": "ReflexioAI/claude-smart",
+        "source": "github"
+      }
+    },
+    "understand-anything": {
+      "source": {
+        "repo": "Egonex-AI/Understand-Anything",
+        "source": "github"
+      }
+    }
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.understand-anything/*.json filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ bin
 .fleet
 **/.env
 .pnpm-store
+.understand-anything/intermediate/
+.understand-anything/tmp/
+.understand-anything/diff-overlay.json

--- a/.understand-anything/.understandignore
+++ b/.understand-anything/.understandignore
@@ -1,0 +1,77 @@
+# .understandignore — patterns for files/dirs to exclude from analysis
+# Syntax: same as .gitignore (globs, # comments, ! negation, trailing / for dirs)
+# Lines below are suggestions — uncomment to activate.
+# Use ! prefix to force-include something excluded by defaults.
+#
+# Built-in defaults (always excluded unless negated):
+#   node_modules/, .git/, dist/, build/, obj/, *.lock, *.min.js, etc.
+#
+# --- From .gitignore (uncomment to exclude) ---
+
+# logs
+# npm-debug.log*
+# yarn-debug.log*
+# yarn-error.log*
+# lerna-debug.log*
+# .pnpm-debug.log*
+# report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+# pids
+# *.pid
+# *.seed
+# *.pid.lock
+# lib-cov
+# *.lcov
+# .nyc_output
+# .grunt
+# bower_components
+# .lock-wscript
+# build/Release
+# jspm_packages/
+# web_modules/
+# *.tsbuildinfo
+# .npm
+# .eslintcache
+# .stylelintcache
+# .rpt2_cache/
+# .rts2_cache_cjs/
+# .rts2_cache_es/
+# .rts2_cache_umd/
+# .node_repl_history
+# *.tgz
+# .yarn-integrity
+# .env.development.local
+# .env.test.local
+# .env.production.local
+# .env.local
+# .parcel-cache
+# .nuxt
+# .vuepress/dist
+# .temp
+# .docusaurus
+# .serverless/
+# .fusebox/
+# .dynamodb/
+# .tern-port
+# .vscode-test
+# .yarn/cache
+# .yarn/unplugged
+# .yarn/build-state.yml
+# .yarn/install-state.gz
+# .pnp.*
+# .husky
+# **/.DS_Store
+# bin
+# .out-bin
+# .fleet
+# **/.env
+# .pnpm-store
+
+# --- Detected directories (uncomment to exclude) ---
+
+# pulumi-test/
+
+# --- Test file patterns (uncomment to exclude) ---
+
+# *.test.*
+# *.spec.*
+# *.snap

--- a/.understand-anything/config.json
+++ b/.understand-anything/config.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cdd9239c41524f81eafba921237cb4ec8ae5d4d51387df01b9e8f28850979e3
+size 25

--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dfebde4072fd7729343239edda99b64ad91cf32c59e5ff68a0f0af517159ddb
+size 36243

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08f5d8dd0b25714571f85fe6812bb55e7fa4648d7da30fa05c20a0ece45863ac
+size 80826

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da70c65052dc9e0401b2206b0bb2d89d8a5b6331f3e5742bb9f29edb5cc32574
+size 158


### PR DESCRIPTION
## What changed

- **`.claude/settings.json`** — shared Claude Code plugin configuration (caveman, claude-smart, context-mode, superpowers, understand-anything, learning-output-style + their marketplace sources). Teammates who clone the repo get the same plugin setup automatically.
- **`.claude/commands/drunk-team-onboard.md`** — adds the `/drunk-team-onboard` slash command. Idempotent one-shot command that generates the settings, rebuilds the Understand-Anything knowledge graph, and stages everything for review. Never commits or pushes itself.
- **`.understand-anything/`** — initial Understand-Anything knowledge graph (knowledge-graph.json, fingerprints.json, meta.json, config.json). All JSON files tracked via git-lfs (LFS pointers in repo, blobs in LFS storage). `autoUpdate: true` keeps the graph incrementally refreshed on every future commit via the plugin's bundled hook.
- **`.gitattributes`** — LFS filter for `.understand-anything/*.json`.
- **`.gitignore`** — excludes intermediate/tmp scratch dirs and `diff-overlay.json` produced by the plugin.

## Why

Onboarding new devs currently requires manually installing Claude Code plugins. This PR makes the repo self-describing: clone → open in Claude Code → plugins auto-install, knowledge graph is ready.

## Follow-up / test notes

- Verify git-lfs is installed on CI runners if they checkout this branch (`git lfs install && git lfs pull`).
- Re-run `/drunk-team-onboard` after significant architectural changes to refresh the graph.
- Private marketplaces listed in `settings.json` require org/repo access — teammates need the appropriate GitHub permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)